### PR TITLE
fix Array initialization and replace depracated functions

### DIFF
--- a/src/methods/get_header.jl
+++ b/src/methods/get_header.jl
@@ -61,10 +61,10 @@ function check_scale(sym::Symbol)
           SourceWaterDepth             
           GroupWaterDepth"
 
-    if contains(recsrc_str, String(sym)) 
+    if occursin(String(sym), recsrc_str) 
         recsrc = true
         scale_name = :RecSourceScalar
-    elseif contains(el_str, String(sym)) 
+    elseif occursin(String(sym), el_str) 
         el = true
         scale_name = :ElevationScalar
     end

--- a/src/read/read_con_headers.jl
+++ b/src/read/read_con_headers.jl
@@ -54,7 +54,7 @@ function read_con_headers(con::SeisCon, keys::Array{String,1}, blocks::Array{Int
         trace_count += ntraces
     end
 
-    return SeisBlock{datatype}(fh, headers[1:trace_count], Array{datatype,2}(0,0))
+    return SeisBlock{datatype}(fh, headers[1:trace_count], Array{datatype,2}(undef,0,0))
     
 end
 
@@ -98,7 +98,7 @@ function read_con_headers(con::SeisCon, blocks::Array{Int,1};
         trace_count += ntraces
     end
 
-    return SeisBlock{datatype}(fh, headers[1:trace_count], Array{datatype,2}(0,0))
+    return SeisBlock{datatype}(fh, headers[1:trace_count], Array{datatype,2}(undef,0,0))
     
 end
 


### PR DESCRIPTION
Found one more Array initialization in which "undef" was missing. Also replaced contains(s1, s2) with occursin(s2, s1)